### PR TITLE
Fix xml module compatibility with lxml 5.x

### DIFF
--- a/plugins/modules/xml.py
+++ b/plugins/modules/xml.py
@@ -438,9 +438,7 @@ def is_attribute(tree, xpath, namespaces):
     An xpath attribute search will only match one item"""
     if xpath_matches(tree, xpath, namespaces):
         match = tree.xpath(xpath, namespaces=namespaces)
-        if isinstance(match[0], etree._ElementStringResult):
-            return True
-        elif isinstance(match[0], etree._ElementUnicodeResult):
+        if isinstance(match[0], str):
             return True
     return False
 


### PR DESCRIPTION
The lxml library removed private classes _ElementStringResult and _ElementUnicodeResult in version 5.1.1 (released March 2024).

These were private internal classes that were never part of the public API. The xml module was using these to detect if XPath results were string attributes.

Since both classes were subclasses of Python's str type, we can simply use isinstance(match[0], str) which works with both old (lxml 4.x) and new (lxml 5.x) versions.

This fix enables compatibility with RHEL 10 / UBI10 which ships with lxml 5.x.

Fixes compatibility issue where tasks using the xml module would fail with: "module 'lxml.etree' has no attribute '_ElementStringResult'"