### PR TITLE
Set license key in galaxy.yml for Automation Hub

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ authors:
   - Guido Grazioli <ggraziol@redhat.com>
   - Ranabir Chakraborty <ranabir@ibm.com>
 description: Common utilities to support Ansible Middleware automation.
-license_file: "LICENSE"
+license: ["Apache-2.0"]
 tags:
   - utilities
   - products


### PR DESCRIPTION
## Summary

Set `license: ["Apache-2.0"]` in galaxy.yml (replacing `license_file: "LICENSE"`) so the license surfaces properly in the Automation Hub UI.

Identified during Automation Hub certification review of `redhat.runtimes_common` v1.2.5.