### PR TITLE
Drop unused fedora.linux_system_roles dependency

### DIFF
--- a/changelogs/fragments/drop_linux_system_roles_dep.yaml
+++ b/changelogs/fragments/drop_linux_system_roles_dep.yaml
@@ -1,0 +1,7 @@
+breaking_changes:
+  - >-
+    Drop unused ``fedora.linux_system_roles`` collection dependency. Consumers
+    that relied on transitive installation of ``fedora.linux_system_roles`` via
+    ``middleware_automation.common`` must add it explicitly to their own
+    ``requirements.yml``. This unblocks using ``community.general`` >= 12.0.0
+    alongside middleware automation collections such as ``middleware_automation.keycloak``.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,6 @@ tags:
   - middleware
   - a4mw
 dependencies:
-  "fedora.linux_system_roles": "*"
   "ansible.posix": ">=1.4.0"
 repository: https://github.com/ansible-middleware/common
 documentation: https://ansible-middleware.github.io/common

--- a/molecule/requirements.yml
+++ b/molecule/requirements.yml
@@ -1,7 +1,6 @@
 ---
 collections:
   - name: ansible.posix
-  - name: fedora.linux_system_roles
   - name: community.general
   - name: community.docker
     version: ">=1.9.1"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,3 @@
 ---
 collections:
-  - name: fedora.linux_system_roles
   - name: ansible.posix


### PR DESCRIPTION
## Summary

- Remove the unused `fedora.linux_system_roles` collection dependency from `galaxy.yml`, `requirements.yml`, and `molecule/requirements.yml`.
- This collection does not reference `fedora.linux_system_roles` in any module, plugin, filter, or role.

## Problem

`fedora.linux_system_roles` requires `community.general:>=6.6.0,<12.0.0` (RHEL 7 Python compatibility). Because `middleware_automation.common` declares it as a transitive dependency, consumers cannot install `middleware_automation.keycloak` (or any collection depending on `common`) alongside `community.general` >= 12.0.0.

Reported in ansible-middleware/keycloak#365 and related to linux-system-roles/linux-system-roles.github.io#137.

## Breaking change / porting

Consumers that relied on transitive installation of `fedora.linux_system_roles` via `middleware_automation.common` must add it explicitly to their own `requirements.yml` if they still need it.

## Test plan

- [ ] `ansible-galaxy collection install` succeeds without pulling `fedora.linux_system_roles`
- [ ] Molecule CI passes
- [ ] Verify dependency resolution allows `community.general` >= 12 alongside `middleware_automation.common`


Made with [Cursor](https://cursor.com)