### PR TITLE
Fix release workflow for protected main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: ansible-middleware/github-actions/.github/workflows/release.yml@main
+    uses: ansible-middleware/github-actions/.github/workflows/release.yml@fix/release-protected-branch-push
     with:
       collection_fqcn: 'middleware_automation.common'
       downstream_name: 'runtimes_common'
@@ -17,6 +17,7 @@ jobs:
     secrets:
       galaxy_token: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
       jira_webhook: ${{ secrets.JIRA_WEBHOOK_CREATE_VERSION }}
+      push_token: ${{ secrets.TRIGGERING_PAT }}
 
   dispatch:
     needs: release


### PR DESCRIPTION
## Summary
- Pass `TRIGGERING_PAT` as `push_token` to the shared release workflow so changelog and version bump commits can push to protected `main`
- Pin the reusable workflow to the matching fix branch in ansible-middleware/github-actions until that PR merges

## Context
Release collection failed in run [28880560905](https://github.com/ansible-middleware/common/actions/runs/28880560905/job/85667334802) because branch protection requires pull requests and `GITHUB_TOKEN` cannot push directly to `main`.

Related: https://github.com/ansible-middleware/github-actions/pull/23

## Test plan
- [ ] Merge this PR and ansible-middleware/github-actions#23
- [ ] Re-run Release collection workflow for v1.2.7


Made with [Cursor](https://cursor.com)